### PR TITLE
Improve line redraw handling

### DIFF
--- a/services/honey.py
+++ b/services/honey.py
@@ -3779,8 +3779,10 @@ def process_command(
 def _read_escape_sequence(chan):
     """Lit une sequence d'echappement provenant du terminal."""
     seq = ""
+    # Utilise un delai un peu plus long pour laisser le temps aux caracteres de
+    # la sequence d'arriver lorsque les touches sont frappees rapidement.
     while True:
-        readable, _, _ = select.select([chan], [], [], 0.01)
+        readable, _, _ = select.select([chan], [], [], 0.1)
         if not readable:
             break
         try:
@@ -3790,7 +3792,11 @@ def _read_escape_sequence(chan):
         if not ch:
             break
         seq += ch
+        # Les sequences ESC O[A-D] utilisent deux lettres. On continue donc
+        # apres le premier 'O' pour recuperer la lettre finale.
         if ch.isalpha() or ch == "~":
+            if seq == "O":
+                continue
             break
     return seq
 
@@ -3815,6 +3821,14 @@ def read_line_advanced(
     history_index = len(history)
     last_completions = []
     tab_count = 0
+
+    def redraw_line():
+        """Redessine la ligne et place le curseur au bon endroit."""
+        # Efface toute la ligne actuelle puis reaffiche le prompt et le buffer
+        chan.send(b"\r\x1b[2K" + prompt.encode() + buffer.encode())
+        diff = len(buffer) - pos
+        if diff > 0:
+            chan.send(f"\x1b[{diff}D".encode())
     while True:
         readable, _, _ = select.select([chan], [], [], 0.1)
         if readable:
@@ -3843,15 +3857,13 @@ def read_line_advanced(
                         tab_count,
                         prompt,
                     )
-                    chan.send(
-                        b"\r" + b" " * 100 + b"\r" + prompt.encode() + buffer.encode()
-                    )
+                    redraw_line()
                     pos = len(buffer)
                 elif data == "\x7f" or data == "\x08":  # Backspace (DEL or BS)
                     if pos > 0:
                         buffer = buffer[: pos - 1] + buffer[pos:]
                         pos -= 1
-                        chan.send(b"\b \b")
+                        redraw_line()
                     last_completions = []
                     tab_count = 0
                 elif data == "\x03":  # Ctrl+C
@@ -3866,13 +3878,9 @@ def read_line_advanced(
                 elif data == "\x04":  # Ctrl+D
                     chan.send(b"logout\r\n")
                     return "exit", jobs, cmd_count
-                elif data in [
-                    "\x1b[A",
-                    "\x1b[B",
-                    "\x1b[C",
-                    "\x1b[D",
-                ]:  # Flèches directionnelles
-                    if data == "\x1b[A":  # Flèche haut
+                elif re.match(r"\x1b\[[0-9;]*[ABCD]$", data) or re.match(r"\x1bO[ABCD]$", data):  # Flèches directionnelles
+                    key = data[-1]
+                    if key == "A":  # Flèche haut
                         if history_index > 0:
                             history_index -= 1
                             buffer = (
@@ -3881,7 +3889,7 @@ def read_line_advanced(
                                 else ""
                             )
                             pos = len(buffer)
-                    elif data == "\x1b[B":  # Flèche bas
+                    elif key == "B":  # Flèche bas
                         if history_index < len(history):
                             history_index += 1
                             buffer = (
@@ -3890,21 +3898,19 @@ def read_line_advanced(
                                 else ""
                             )
                             pos = len(buffer)
-                    elif data == "\x1b[C":  # Flèche droite
+                    elif key == "C":  # Flèche droite
                         if pos < len(buffer):
                             pos += 1
-                    elif data == "\x1b[D":  # Flèche gauche
+                    elif key == "D":  # Flèche gauche
                         if pos > 0:
                             pos -= 1
-                    chan.send(
-                        b"\r" + b" " * 100 + b"\r" + prompt.encode() + buffer.encode()
-                    )
+                    redraw_line()
                     last_completions = []
                     tab_count = 0
                 elif len(data) == 1 and ord(data) >= 32:  # Caractères imprimables
                     buffer = buffer[:pos] + data + buffer[pos:]
                     pos += 1
-                    chan.send(data.encode())
+                    redraw_line()
                     last_completions = []
                     tab_count = 0
             except UnicodeDecodeError:


### PR DESCRIPTION
## Summary
- clear entire line with `ESC[2K` before rewriting prompt and buffer
- wait longer for escape sequence characters

## Testing
- `python -m py_compile services/honey.py`
- `python -m py_compile services/ssh_honeypot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea6c92e70833186d5d742ce31bb9c